### PR TITLE
feat: add dynamic movement test, improve GPS/location error handling, and change broker

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,28 +3,34 @@
 This application leverages the [**Collektive**](https://github.com/Collektive/collektive) **library** to model a decentralized communication system based on spatial proximity. Connected devices can send and receive messages within a global chat, provided they are within a certain distance of each other.
 
 The project is currently under development and offers a minimal working version as a proof of concept.
+# 🔄 MQTT Broker Information
 
-# How To Run
+This application **currently uses the public broker** provided by **EMQX** at: `broker.emqx.io`.
+
+However, the app was developed and tested using a **local Mosquitto broker**.  
+If you prefer to run your own broker locally (recommended for development), follow the tutorial below to install and configure **Eclipse Mosquitto**.
+
+## How To Run
 - Install Mosquitto 
 - Change IP_HOST value in:
   - [MessagesViewModel.kt](app/src/main/java/it/unibo/collektive/viewmodels/MessagesViewModel.kt) 
   - [NearbyDevicesViewModel.kt](app/src/main/java/it/unibo/collektive/viewmodels/NearbyDevicesViewModel.kt)
 
-# 🧪 Local MQTT Broker For Development
+## 🧪 Local MQTT Broker For Development
 
 This guide explains how to install and run a **local MQTT broker** using **Eclipse Mosquitto**.
 
 ---
 
-## ✅ Goal
+### ✅ Goal
 
 Install a local MQTT broker accessible at `localhost:1883`.
 
 ---
 
-## 🧰 Installing Mosquitto
+### 🧰 Installing Mosquitto
 
-### 🔹 Windows
+#### 🔹 Windows
 
 1. Go to [mosquitto.org/download/](https://mosquitto.org/download/)
 2. Find the **Windows** section
@@ -35,16 +41,16 @@ Install a local MQTT broker accessible at `localhost:1883`.
     - ✅ Use a default path (`C:\Program Files\mosquitto`)
     - ✅ Insert `C:\Program Files\mosquitto` path in to environment variables of the system
 
-### 🔹 Linux (Debian/Ubuntu)
+#### 🔹 Linux (Debian/Ubuntu)
 
 ```bash
     sudo apt update
     sudo apt install mosquitto mosquitto-clients
 ```
 
-## 🚀 Running The Broker
+### 🚀 Running The Broker
 
-### ▶️ Windows
+#### ▶️ Windows
 
 ```shell
     mosquitto -v -c "mosquitto/config/mosquitto.conf"
@@ -61,7 +67,7 @@ To stop:
    net stop mosquitto
 ```
 
-### ▶️ Linux
+#### ▶️ Linux
 
 Copy your configuration file to the Mosquitto config directory:
 ```bash

--- a/app/src/main/java/it/unibo/collektive/viewmodels/MessagesViewModel.kt
+++ b/app/src/main/java/it/unibo/collektive/viewmodels/MessagesViewModel.kt
@@ -135,6 +135,23 @@ class MessagesViewModel(
     val messages: StateFlow<List<Message>> = _messages.asStateFlow()
 
     /**
+     * Epoch time (in milliseconds) indicating when this device became a source.
+     *
+     * This is `null` if the device is not currently a source.
+     * Used exclusively for testing purposes.
+     */
+    private val _sourceSince = MutableStateFlow<Long?>(null)
+    val sourceSince: StateFlow<Long?> get() = _sourceSince
+
+    fun markAsSource(now: Long = System.currentTimeMillis()) {
+        _sourceSince.value = now
+    }
+
+    fun clearSourceStatus() {
+        _sourceSince.value = null
+    }
+
+    /**
      * Integrates newly received messages into the current local message list,
      * ensuring that duplicates and previously deleted messages are not re-added.
      *
@@ -241,6 +258,10 @@ class MessagesViewModel(
         _sendFlag.value = flag
     }
 
+    fun getSendFlag(): Boolean {
+        return _sendFlag.value
+    }
+
     /**
      * Updates the current geographic location of the device.
      *
@@ -252,6 +273,10 @@ class MessagesViewModel(
     fun setLocation(location: Location?) {
         _position.value = location
         _coordinates.value = Point3D(Triple(_position.value!!.latitude, _position.value!!.longitude, _position.value!!.altitude))
+    }
+
+    fun getLocation(): Location? {
+        return _position.value
     }
 
     /**
@@ -590,7 +615,7 @@ class MessagesViewModel(
         deviceId: Uuid,
         userName: String,
         distance: Float,
-        position: Point3D = _coordinates.value!!,
+        position: Point3D = _coordinates.value?: Point3D(Triple(Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE)),
         message: String,
         nearbyDevicesViewModel: NearbyDevicesViewModel,
         time: LocalDateTime
@@ -783,6 +808,6 @@ class MessagesViewModel(
 
 
     companion object {
-        private const val IP_HOST = "192.168.1.5"
+        private const val IP_HOST = "broker.emqx.io"
     }
 }

--- a/app/src/main/java/it/unibo/collektive/viewmodels/NearbyDevicesViewModel.kt
+++ b/app/src/main/java/it/unibo/collektive/viewmodels/NearbyDevicesViewModel.kt
@@ -122,6 +122,6 @@ class NearbyDevicesViewModel(
     }
 
     companion object {
-        private const val IP_HOST = "192.168.1.5"
+        private const val IP_HOST = "broker.emqx.io"
     }
 }


### PR DESCRIPTION
- Added instrumentation test `dynamic movement and message propagation` to simulate devices moving and sending messages with cooldown.
- Improved GPS availability handling to prevent message send failures after location is enabled at runtime.
- Ensured `errorPositionPopup` is reset when valid location becomes available.
- UI now correctly waits for location before allowing message sending.